### PR TITLE
Fix XML parsing for Lightning and Soundings when no data are returned

### DIFF
--- a/fmiopendata/lightning.py
+++ b/fmiopendata/lightning.py
@@ -89,7 +89,12 @@ class Lightning(object):
         Version for fmi::observations::lightning::multipointcoverage query.
 
         """
-        positions = np.fromstring(self._xml.findtext(wfs.GMLCOV_POSITIONS), dtype=float, sep=" ")
+        try:
+            positions = np.fromstring(self._xml.findtext(wfs.GMLCOV_POSITIONS), dtype=float, sep=" ")
+        except TypeError:
+            print("No observations found")
+            self._set_empty_observations()
+            return
         self.latitudes = positions[::3]
         self.longitudes = positions[1::3]
         times = positions[2::3]
@@ -100,6 +105,15 @@ class Lightning(object):
         for i, field in enumerate(fields):
             vals = data[i::len(fields)]
             setattr(self, field, vals)
+
+    def _set_empty_observations(self):
+        self.latitudes = np.array([])
+        self.longitudes = np.array([])
+        self.times = np.array([])
+        self.multiplicity = np.array([], dtype=np.uint8)
+        self.peak_current = np.array([])
+        self.cloud_indicator = np.array([], dtype=np.uint8)
+        self.ellipse_major = np.array([])
 
 
 def download_and_parse(query_id, args=None):

--- a/fmiopendata/sounding.py
+++ b/fmiopendata/sounding.py
@@ -83,7 +83,11 @@ class ParseSoundings(object):
             sounding.start_time = dt.datetime.strptime(member.findtext(wfs.GML_BEGIN_POSITION), TIME_FORMAT)
             sounding.end_time = dt.datetime.strptime(member.findtext(wfs.GML_END_POSITION), TIME_FORMAT)
 
-            positions = np.fromstring(member.findtext(wfs.GMLCOV_POSITIONS), dtype=float, sep=" ")
+            try:
+                positions = np.fromstring(member.findtext(wfs.GMLCOV_POSITIONS), dtype=float, sep=" ")
+            except TypeError:
+                print("No soundings found")
+                return
             sounding.lats = positions[::4]
             sounding.lons = positions[1::4]
             sounding.altitudes = positions[2::4]

--- a/fmiopendata/tests/test_lightning.py
+++ b/fmiopendata/tests/test_lightning.py
@@ -73,3 +73,27 @@ def test_unimplemented(read_url, ET):
 
     with pytest.raises(NotImplementedError):
         _ = download_and_parse("fmi::observations::lightning::nonexistent", args=ARGS)
+
+
+def test_no_data():
+    """"Test that missing data is handled properly."""
+    from fmiopendata.lightning import Lightning
+
+    empty_xml = "<xml></xml>"
+    # "::simple" data
+    obs = Lightning(empty_xml, "simple")
+    _check_lightning_empty(obs)
+
+    # "::multipointcoverage" data
+    obs = Lightning(empty_xml, "multipointcoverage")
+    _check_lightning_empty(obs)
+
+
+def _check_lightning_empty(obs):
+    np.testing.assert_equal(obs.latitudes, np.array([]))
+    np.testing.assert_equal(obs.longitudes, np.array([]))
+    np.testing.assert_equal(obs.times, np.array([]))
+    np.testing.assert_equal(obs.multiplicity, np.array([], dtype=np.uint8))
+    np.testing.assert_equal(obs.peak_current, np.array([]))
+    np.testing.assert_equal(obs.cloud_indicator, np.array([], dtype=np.uint8))
+    np.testing.assert_equal(obs.ellipse_major, np.array([]))

--- a/fmiopendata/tests/test_sounding.py
+++ b/fmiopendata/tests/test_sounding.py
@@ -52,3 +52,17 @@ def test_args(read_url, ParseSoundings):
     res = download_and_parse("foo", args=["a=1", "b=2"])
     del res
     assert read_url.mock_calls[0].endswith("=foo&a=1&b=2")
+
+
+def test_no_data():
+    """"Test that missing data is handled properly."""
+    from fmiopendata.sounding import ParseSoundings
+
+    empty_xml = "<xml></xml>"
+
+    obs = ParseSoundings(empty_xml)
+    _check_soundings_empty(obs)
+
+
+def _check_soundings_empty(obs):
+    assert obs.soundings == []


### PR DESCRIPTION
This PR fixes the `Lightning` and `Sounding` parsers for cases when no data are returned. This also ensures that the results from `simple` and `multipointcoverage` queries are equal when no data are received.

Closes #6 