### PR TITLE
Add requests to required packages

### DIFF
--- a/fmiopendata/multipoint.py
+++ b/fmiopendata/multipoint.py
@@ -125,6 +125,7 @@ def _parse_times(xml, positions):
 
 def _parse_measurements(xml, shape):
     measurements = np.fromstring(xml.findtext(wfs.GML_DOUBLE_OR_NIL_REASON_TUPLE_LIST), dtype=float, sep=" ")
+    import ipdb; ipdb.set_trace()
     return np.reshape(measurements, shape)
 
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@
 from setuptools import setup
 from fmiopendata import __version__
 
-install_requires = ['numpy']
+install_requires = ['numpy', 'requests']
 extras_require = {'radar': ['rasterio'],
                   'grid': ['eccodes'],
                   }


### PR DESCRIPTION
The `requests` module was missing from the install requirements. Closes #24 