### PR TITLE
Use the safer defusedxml library for XML parsing.

### DIFF
--- a/bin/wfs_html.py
+++ b/bin/wfs_html.py
@@ -20,7 +20,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 
 import sys
 

--- a/fmiopendata/grid.py
+++ b/fmiopendata/grid.py
@@ -20,7 +20,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import datetime as dt
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 import os
 import tempfile
 import sys

--- a/fmiopendata/lightning.py
+++ b/fmiopendata/lightning.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 import datetime as dt
 
 import numpy as np

--- a/fmiopendata/multipoint.py
+++ b/fmiopendata/multipoint.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 import datetime as dt
 import sys
 if sys.version_info < (3, 6):

--- a/fmiopendata/radar.py
+++ b/fmiopendata/radar.py
@@ -20,7 +20,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import datetime as dt
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 import tempfile
 import sys
 if sys.version_info < (3, 6):

--- a/fmiopendata/sounding.py
+++ b/fmiopendata/sounding.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 import datetime as dt
 
 import numpy as np

--- a/fmiopendata/utils.py
+++ b/fmiopendata/utils.py
@@ -23,7 +23,7 @@ from urllib.request import urlretrieve
 import warnings
 
 import requests
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 
 EXCEPTION_TEXT = './/{http://www.opengis.net/ows/1.1}ExceptionText'
 

--- a/fmiopendata/wfs.py
+++ b/fmiopendata/wfs.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 import sys
 if sys.version_info < (3, 6):
     from collections import OrderedDict as dict

--- a/fmiopendata/wms.py
+++ b/fmiopendata/wms.py
@@ -20,7 +20,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import datetime as dt
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 import sys
 if sys.version_info < (3, 6):
     from collections import OrderedDict as dict

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@
 from setuptools import setup
 from fmiopendata import __version__
 
-install_requires = ['numpy', 'requests']
+install_requires = ['numpy', 'requests', 'defusedxml']
 extras_require = {'radar': ['rasterio'],
                   'grid': ['eccodes'],
                   }


### PR DESCRIPTION
Even the official Python xml lib documentation strongly recommends using the defusedxml library.