### PR TITLE
Bugfix timeseries key names

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ print(sorted(obs.data[latest_tstep].keys()))
 # as an example below
 
 # On the third level we find the names of the observed parameters
-# print(sorted(obs.data[latest_tstep]["Kustavi Isokari"].keys()))
+print(sorted(obs.data[latest_tstep]["Kustavi Isokari"].keys()))
 # -> ['Air temperature',
 #     'Cloud amount',
 #     'Dew-point temperature',
@@ -412,7 +412,7 @@ times = obs.data['Helsinki Malmi lentokenttä']['times']
 # Other data fields have another extra level, one for values and one for the unit
 print(len(obs.data['Helsinki Malmi lentokenttä']['t2m']['values']))
 # -> 71
-print(obs.data['Helsinki Malmi lentokenttä']['t2m']['unit'])
+print(obs.data['Helsinki Malmi lentokenttä']['Air temperature']['unit'])
 # -> 'degC'
 ```
 

--- a/fmiopendata/multipoint.py
+++ b/fmiopendata/multipoint.py
@@ -91,9 +91,9 @@ class MultiPoint(object):
                 self.data[name] = dict(times=[])
             self.data[name]["times"].append(tim)
             for j, key in enumerate(type2obs.keys()):
-                if key not in self.data[name]:
-                    self.data[name][key] = {"values": [], "unit": type2obs[key]["units"]}
-                self.data[name][key]["values"].append(measurements[i, j])
+                if type2obs[key]["name"] not in self.data[name]:
+                    self.data[name][type2obs[key]["name"]] = {"values": [], "unit": type2obs[key]["units"]}
+                self.data[name][type2obs[key]["name"]]["values"].append(measurements[i, j])
 
     def _collect_non_timeseries(self, type2obs, latitudes, longitudes, times, measurements):
         for i, tim in enumerate(times):


### PR DESCRIPTION
The measurement keys ("titles") for timeseries observations were using the standard short-form naming, such as `'t2m'` instead of the human-readable `"Air temperature"` that are used when `timeseries=False` is used. This PR harmonizes the `timeseries=True` case to use the longer key names.