### PR TITLE
fix: fallback to field name if metadata is missing

### DIFF
--- a/fmiopendata/multipoint.py
+++ b/fmiopendata/multipoint.py
@@ -133,7 +133,9 @@ def _parse_names_and_units(xml):
         try:
             url = field.attrib[wfs.LINK]
             root = ET.fromstring(read_url(url))
-            name = root.findtext(wfs.OMOP_LABEL)
+            # fallback to something if OMOP label is not found
+            # this happens when FMI has not provided proper metadata for a field
+            name = root.findtext(wfs.OMOP_LABEL) or typ
             try:
                 units = root.find(wfs.OMOP_UOM).attrib["uom"]
             except AttributeError:

--- a/fmiopendata/tests/test_multipoint.py
+++ b/fmiopendata/tests/test_multipoint.py
@@ -37,6 +37,17 @@ ARGS_OLD = ["bbox=24,59,26,61",
             "endtime=" + END_TIME_OLD.isoformat(timespec="seconds") + "Z"]
 ARGS_TIMESERIES = ["bbox=24,59,26,61", "timeseries=True"]
 
+forecast_start = dt.datetime.now()
+forecast_end = forecast_start + dt.timedelta(hours=1)
+
+ARGS_FORECAST = [
+    "bbox=24,59,26,61",
+    "starttime=" + forecast_start.isoformat(timespec="seconds") + "Z",
+    "endtime=" + forecast_end.isoformat(timespec="seconds") + "Z",
+    "place=Helsinki",
+    "parameters=PoP",  # PoP is missing metadata as of September 2025
+]
+
 
 def test_multipoint_mareograph_default():
     """Test multipoint coverage parser for default query of mareograph data."""
@@ -124,3 +135,17 @@ def test_multipoint_radionuclide():
     res = download_and_parse("stuk::observations::air::radionuclide-activity-concentration::latest::multipointcoverage",
                              args=ARGS)
     _verify_multipoint_common(res)
+
+
+def test_multipoint_missing_metadata_for_field():
+    from fmiopendata.multipoint import download_and_parse
+
+    res = download_and_parse(
+        "fmi::forecast::edited::weather::scandinavia::point::multipointcoverage",
+        args=ARGS_FORECAST,
+    )
+
+    for step, step_data in res.data.items():
+        for loc, data in step_data.items():
+            keys = data.keys()
+            assert None not in keys, f"None in parsed keys {keys} for {step} and {loc}"


### PR DESCRIPTION
in some cases there is no metadata available for some fields and it results field names to be `None`. this diff adds a fallback for such cases.

repro in python repl:

```python
from fmiopendata.wfs import download_stored_query
import datetime as dt

now = dt.datetime.now()
start_time = now.strftime("%Y-%m-%dT00:00:00Z")
end_time = now.strftime("%Y-%m-%dT01:00:00Z")

model_data = download_stored_query(
	"fmi::forecast::edited::weather::scandinavia::point::multipointcoverage",
	args=[
		"starttime=" + start_time,
		"endtime=" + end_time,
		"place=Helsinki",
		"parameters=PoP",
	],
)

for key in model_data.data.keys():
	model_data.data[key]
```