### PR TITLE
Feature: Add FMI Open Data WFS station metadata parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The `Query ID` is the handle that can be used to request data from WFS stored qu
 * [Download and parse latest lightning data](#download-and-parse-latest-lightning-data)
 * [Download and parse grid data](#download-and-parse-grid-data)
 * [Download and parse observation data](#download-and-parse-observation-data)
+* [Download and parse station metadata](#download-and-parse-station-metadata)
 
 ### Download and parse latest soundings
 ```python
@@ -416,8 +417,78 @@ print(obs.data['Helsinki Malmi lentokenttä']['Air temperature']['unit'])
 # -> 'degC'
 ```
 
+### Download and parse station metadata
+
+```python
+from fmiopendata.wfs import download_stored_query
+
+stations = download_stored_query("fmi::ef::stations")
+```
+
+The structure of the returned `Station` class is
+
+```python
+Station.data  # The station metadata
+```
+
+The `data` dictionary has the following structure:
+
+```python
+{
+    station: {
+        'id': gml_id,
+        'fmisid': fmisid,
+        'geoid': geoid,
+        'wmo': wmo_id,
+        'name': station_name,
+        'region': region,
+        'country': country,
+        'station_type': [station_type1, station_type2, ...],  # List of network types
+        'latitude': latitude,
+        'longitude': longitude,
+        'start_time': begin_datetime,
+        'end_time': end_datetime,
+        'inspire_local_id': inspire_local_id,
+        'inspire_namespace': inspire_namespace,
+        'measurement_regime': measurement_regime,
+        'mobile': mobile  # Boolean
+    },
+    ...
+}
+```
+
+The following queries can be used to retrieve station data:
+
+```python
+
+# Get a specific station by its ID
+station_id = '100971'
+station = stations.get_station_by_id(station_id)
+print(station['name'])  # -> 'Helsinki Kaisaniemi'
+print(station['station_type'])  # -> ['Ilmastoasema']
+
+# Get a single station by its name
+station_name = 'Helsinki Kaisaniemi'
+station = stations.get_station_by_name(station_name)
+
+# Get all stations of a specific network type
+station_type = 'Ilmastoasema'
+climate_stations = stations.get_stations_by_type(station_type)
+
+# Get all stations in a specific country
+country = 'Finland'
+finnish_stations = stations.get_stations_by_country(country)
+
+# Get all stations in a specific region
+region = 'Helsinki'
+helsinki_stations = stations.get_stations_by_region(region)
+```
+
+## Supported stored queries
+
 This parser supports at least the following stored queries:
 
+* `fmi::ef::stations`
 * `fmi::forecast::hirlam::surface::obsstations::multipointcoverage`
 * `fmi::forecast::oaas::sealevel::point::multipointcoverage`
 * `fmi::observations::airquality::hourly::multipointcoverage`

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ members is common to all `grid` type WFS data.
 
 The data arrays will have invalid values replaced with `np.nan`.
 
-## Download and parse observation data
+### Download and parse observation data
 ```python
 import datetime as dt
 

--- a/fmiopendata/station.py
+++ b/fmiopendata/station.py
@@ -1,0 +1,322 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) Panu Lahtinen
+#
+# Author(s):
+#
+#   Panu Lahtinen <pnuu+git@iki.fi>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import sys
+import defusedxml.ElementTree as ET
+import datetime as dt
+import numpy as np
+
+from xml.etree.ElementTree import Element
+from typing import List, Dict, Optional
+
+# Add the parent directory to the Python path when running as a script
+if __name__ == "__main__":
+    sys.path.insert(0, os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..")
+    ))
+
+from fmiopendata import wfs
+from fmiopendata.utils import read_url
+
+TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+
+# Add the needed possibly missing constants
+# to wfs module when running as script.
+if __name__ == "__main__":
+    if not hasattr(wfs, "EF_ENVIRONMENTAL_MONITORING_FACILITY"):
+        wfs.EF_ENVIRONMENTAL_MONITORING_FACILITY = (
+            ".//{http://inspire.ec.europa.eu/schemas/ef/4.0}"
+            "EnvironmentalMonitoringFacility"
+        )
+    if not hasattr(wfs, "EF_NAME"):
+        wfs.EF_NAME = (
+            ".//{http://inspire.ec.europa.eu/schemas/ef/4.0}name"
+        )
+    if not hasattr(wfs, "EF_BELONGS_TO"):
+        wfs.EF_BELONGS_TO = (
+            ".//{http://inspire.ec.europa.eu/schemas/ef/4.0}belongsTo"
+        )
+    if not hasattr(wfs, "XLINK_TITLE"):
+        wfs.XLINK_TITLE = "{http://www.w3.org/1999/xlink}title"
+    if not hasattr(wfs, "GML_TIME_PERIOD"):
+        wfs.GML_TIME_PERIOD = (
+            ".//{http://www.opengis.net/gml/3.2}TimePeriod"
+        )
+    if not hasattr(wfs, "EF_INSPIRE_ID"):
+        wfs.EF_INSPIRE_ID = (
+            ".//{http://inspire.ec.europa.eu/schemas/ef/4.0}inspireId"
+        )
+    if not hasattr(wfs, "INS_BASE_LOCAL_ID"):
+        wfs.INS_BASE_LOCAL_ID = (
+            ".//{http://inspire.ec.europa.eu/schemas/base/3.3}localId"
+        )
+    if not hasattr(wfs, "INS_BASE_NAMESPACE"):
+        wfs.INS_BASE_NAMESPACE = (
+            ".//{http://inspire.ec.europa.eu/schemas/base/3.3}namespace"
+        )
+    if not hasattr(wfs, "EF_MOBILE"):
+        wfs.EF_MOBILE = (
+            ".//{http://inspire.ec.europa.eu/schemas/ef/4.0}mobile"
+        )
+    if not hasattr(wfs, "EF_MEASUREMENT_REGIME"):
+        wfs.EF_MEASUREMENT_REGIME = (
+            ".//{http://inspire.ec.europa.eu/schemas/ef/4.0}"
+            "measurementRegime"
+        )
+
+
+class Station(object):
+    """Class representing a weather station."""
+
+    def __init__(self, xml: str) -> None:
+        """Initialize class."""
+        self._xml = ET.fromstring(xml)
+        self.data = dict()
+
+        self._parse(self._xml)
+
+    def _parse(self, xml: Element) -> None:
+        """Parse station data."""
+        # Get all station entries from the XML
+        for member in xml.findall(wfs.WFS_MEMBER):
+            facility = member.find(wfs.EF_ENVIRONMENTAL_MONITORING_FACILITY)
+            if facility is None:
+                continue
+
+            # Extract the station ID
+            station_id_elem = facility.find(wfs.GML_IDENTIFIER)
+            if station_id_elem is None:
+                continue
+
+            station_id = station_id_elem.text
+
+            # Initialize station data dictionary with flattened structure
+            station_data = {
+                "id": facility.get(wfs.GML_ID),
+                "fmisid": station_id,
+                "geoid": None,
+                "wmo": None,
+                "name": None,
+                "region": None,
+                "country": None,
+                "station_type": [],
+                "latitude": None,
+                "longitude": None,
+                "start_time": None,
+                "end_time": None,
+                "inspire_local_id": None,
+                "inspire_namespace": None,
+                "measurement_regime": None,
+                "mobile": None,
+            }
+
+            # Extract station names and other identifiers
+            for name_elem in facility.findall(wfs.GML_NAME):
+                code_space = name_elem.get("codeSpace", "")
+                if "locationcode/name" in code_space:
+                    station_data["name"] = name_elem.text
+                elif "locationcode/geoid" in code_space:
+                    station_data["geoid"] = name_elem.text
+                elif "locationcode/wmo" in code_space:
+                    station_data["wmo"] = name_elem.text
+                elif "location/region" in code_space:
+                    station_data["region"] = name_elem.text
+                elif "location/country" in code_space:
+                    station_data["country"] = name_elem.text
+
+            # If name wasn't found in gml:name, try ef:name
+            if station_data["name"] is None:
+                name_elem = facility.find(wfs.EF_NAME)
+                if name_elem is not None:
+                    station_data["name"] = name_elem.text
+
+            # Extract INSPIRE ID
+            inspire_id_elem = facility.find(wfs.EF_INSPIRE_ID)
+            if inspire_id_elem is not None:
+                local_id_elem = inspire_id_elem.find(wfs.INS_BASE_LOCAL_ID)
+                namespace_elem = inspire_id_elem.find(
+                    wfs.INS_BASE_NAMESPACE
+                )
+                if local_id_elem is not None:
+                    station_data["inspire_local_id"] = local_id_elem.text
+                if namespace_elem is not None:
+                    station_data["inspire_namespace"] = namespace_elem.text
+
+            # Extract station position
+            point_elem = facility.find(wfs.GML_POINT)
+            if point_elem is not None:
+                pos_elem = point_elem.find(wfs.GML_POS)
+                if pos_elem is not None:
+                    coords = pos_elem.text.split()
+                    station_data["latitude"] = float(coords[0])
+                    station_data["longitude"] = float(coords[1])
+
+            # Extract measurement regime
+            regime_elem = facility.find(wfs.EF_MEASUREMENT_REGIME)
+            if regime_elem is not None:
+                href = regime_elem.get(wfs.LINK)
+                if href:
+                    # Extract the value from the URL
+                    station_data["measurement_regime"] = (
+                        href.split("/")[-1]
+                    )
+
+            # Extract mobile status
+            mobile_elem = facility.find(wfs.EF_MOBILE)
+            if mobile_elem is not None and mobile_elem.text:
+                station_data["mobile"] = (
+                    mobile_elem.text.lower() == "true"
+                )
+
+            # Extract time period
+            time_period_elem = facility.find(wfs.GML_TIME_PERIOD)
+            if time_period_elem is not None:
+                begin_elem = time_period_elem.find(wfs.GML_BEGIN_POSITION)
+                end_elem = time_period_elem.find(wfs.GML_END_POSITION)
+
+                if begin_elem is not None and begin_elem.text:
+                    try:
+                        station_data["start_time"] = dt.datetime.strptime(
+                            begin_elem.text, TIME_FORMAT
+                        )
+                    except ValueError:
+                        pass
+
+                if end_elem is not None:
+                    if end_elem.get("indeterminatePosition") == "now":
+                        station_data["end_time"] = dt.datetime.now()
+                    elif end_elem.text:
+                        try:
+                            station_data["end_time"] = dt.datetime.strptime(
+                                end_elem.text, TIME_FORMAT
+                            )
+                        except ValueError:
+                            pass
+
+            # Extract station network types (can be multiple)
+            belongs_elems = facility.findall(wfs.EF_BELONGS_TO)
+            for belongs_elem in belongs_elems:
+                title = belongs_elem.get(wfs.XLINK_TITLE)
+                if title:
+                    station_data["station_type"].append(title)
+
+            # Add station data to the main data dictionary
+            self.data[station_id] = station_data
+
+    def _parse_times(
+        self,
+        xml: Element,
+        positions: List[float]
+    ) -> np.ndarray:
+        """Parse time data from GML positions."""
+        times = np.array(
+            [
+                dt.datetime(1970, 1, 1) + dt.timedelta(seconds=t)
+                for t in positions[2::3]
+            ]
+        )
+        if times.size == 0:
+            times = np.array(
+                [
+                    dt.datetime.strptime(
+                        xml.findtext(wfs.GML_TIME_POSITION),
+                        TIME_FORMAT
+                    )
+                ]
+            )
+        return times
+
+    def get_station_by_id(self, station_id: str) -> Optional[Dict]:
+        """Get station information by its ID."""
+        return self.data.get(station_id)
+
+    def get_station_by_name(
+        self,
+        name: str
+    ) -> Optional[Dict]:
+        """Get station information by its name."""
+        for _, station_data in self.data.items():
+            if station_data["name"] == name:
+                return station_data
+        return None
+
+    def get_stations_by_type(self, station_type: str) -> Optional[Dict]:
+        """Get all stations of a specific type."""
+        return {
+            station_id: station_data
+            for station_id, station_data in self.data.items()
+            if station_type in station_data["station_type"]
+        }
+
+    def get_stations_by_country(self, country: str) -> Optional[Dict]:
+        """Get all stations in a specific country."""
+        return {
+            station_id: station_data
+            for station_id, station_data in self.data.items()
+            if station_data["country"] == country
+        }
+
+    def get_stations_by_region(self, region: str) -> Optional[Dict]:
+        """Get all stations in a specific region."""
+        return {
+            station_id: station_data
+            for station_id, station_data in self.data.items()
+            if station_data["region"] == region
+        }
+
+
+def download_and_parse(
+        query_id: str = "fmi::ef::stations",
+        args: List[str] = None
+) -> Station:
+    """Download and parse the data for the given stored query ID."""
+    if args is None:
+        args = []
+    url = wfs.STORED_QUERY_URL + query_id
+    if args:
+        url = url + "&" + "&".join(args)
+    xml = read_url(url)
+
+    if query_id == "fmi::ef::stations":
+        # Handling of the weather station data from FMI Open Data WFS service.
+        return Station(xml)
+    else:
+        raise NotImplementedError(
+            f"Custom parsing for query ID '{query_id}' not implemented!"
+        )
+
+
+if __name__ == "__main__":
+    START_TIME = dt.datetime(1829, 1, 1, 0, 0, 0)
+    END_TIME = dt.datetime(2025, 7, 7, 12, 5, 0)
+
+    ARGS = [
+        "starttime=" + START_TIME.isoformat(timespec="seconds") + "Z",
+        "endtime=" + END_TIME.isoformat(timespec="seconds") + "Z",
+    ]
+
+    # Example usage
+    station_data = download_and_parse("fmi::ef::stations", args=ARGS)
+    # for station_id, info in station_data.data.items():
+    #     print(f"Station ID: {station_id}, Name: {info['name']},
+    #           Country: {info['country']}")
+    print(station_data.data)

--- a/fmiopendata/station.py
+++ b/fmiopendata/station.py
@@ -195,20 +195,16 @@ class Station(object):
 
                 if begin_elem is not None and begin_elem.text:
                     try:
-                        station_data["start_time"] = dt.datetime.strptime(
-                            begin_elem.text, TIME_FORMAT
-                        )
+                        station_data["start_time"] = begin_elem.text
                     except ValueError:
                         pass
 
                 if end_elem is not None:
                     if end_elem.get("indeterminatePosition") == "now":
-                        station_data["end_time"] = dt.datetime.now()
+                        station_data["end_time"] = dt.datetime.now().strftime(TIME_FORMAT)
                     elif end_elem.text:
                         try:
-                            station_data["end_time"] = dt.datetime.strptime(
-                                end_elem.text, TIME_FORMAT
-                            )
+                            station_data["end_time"] = end_elem.text
                         except ValueError:
                             pass
 
@@ -230,7 +226,7 @@ class Station(object):
         """Parse time data from GML positions."""
         times = np.array(
             [
-                dt.datetime(1970, 1, 1) + dt.timedelta(seconds=t)
+                (dt.datetime(1970, 1, 1) + dt.timedelta(seconds=t)).strftime(TIME_FORMAT)
                 for t in positions[2::3]
             ]
         )
@@ -240,7 +236,7 @@ class Station(object):
                     dt.datetime.strptime(
                         xml.findtext(wfs.GML_TIME_POSITION),
                         TIME_FORMAT
-                    )
+                    ).strftime(TIME_FORMAT)
                 ]
             )
         return times

--- a/fmiopendata/station.py
+++ b/fmiopendata/station.py
@@ -306,13 +306,7 @@ def download_and_parse(
 
 
 if __name__ == "__main__":
-    START_TIME = dt.datetime(1829, 1, 1, 0, 0, 0)
-    END_TIME = dt.datetime(2025, 7, 7, 12, 5, 0)
-
-    ARGS = [
-        "starttime=" + START_TIME.isoformat(timespec="seconds") + "Z",
-        "endtime=" + END_TIME.isoformat(timespec="seconds") + "Z",
-    ]
+    ARGS = []
 
     # Example usage
     station_data = download_and_parse("fmi::ef::stations", args=ARGS)

--- a/fmiopendata/tests/test_station.py
+++ b/fmiopendata/tests/test_station.py
@@ -29,6 +29,7 @@ import warnings
 
 START_TIME = dt.datetime(1829, 1, 1, 0, 0, 0)
 END_TIME = dt.datetime(2025, 7, 7, 12, 5, 0)
+TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
 ARGS = [
     "starttime=" + START_TIME.isoformat(timespec="seconds") + "Z",
@@ -132,13 +133,21 @@ class TestStationParser:
             # Check start_time if it exists
             if station_data["start_time"] is not None:
                 assert isinstance(
-                    station_data["start_time"], dt.datetime
+                    dt.datetime.strptime(
+                        station_data["start_time"],
+                        TIME_FORMAT
+                    ),
+                    dt.datetime
                 ), "Start time should be a datetime"
 
             # Check end_time if it exists
             if station_data["end_time"] is not None:
                 assert isinstance(
-                    station_data["end_time"], dt.datetime
+                    dt.datetime.strptime(
+                        station_data["end_time"],
+                        TIME_FORMAT
+                    ),
+                    dt.datetime
                 ), "End time should be a datetime"
 
     def test_get_station_by_id(self):

--- a/fmiopendata/tests/test_station.py
+++ b/fmiopendata/tests/test_station.py
@@ -1,0 +1,556 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) Panu Lahtinen
+#
+# Author(s):
+#
+#   Panu Lahtinen <pnuu+git@iki.fi>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test station data parsers."""
+
+import datetime as dt
+from fmiopendata.station import Station, download_and_parse
+import warnings
+
+
+START_TIME = dt.datetime(1829, 1, 1, 0, 0, 0)
+END_TIME = dt.datetime(2025, 7, 7, 12, 5, 0)
+
+ARGS = [
+    "starttime=" + START_TIME.isoformat(timespec="seconds") + "Z",
+    "endtime=" + END_TIME.isoformat(timespec="seconds") + "Z",
+]
+
+
+def _test_verify_station_common(res):
+    """Verify basic aspects of station data."""
+    # Check that result is a Station object
+    assert isinstance(res, Station), "Result should be a Station instance"
+
+    # Check that data is not empty
+    assert res.data, "Station data should not be empty"
+
+
+class TestStationParser:
+    """Test suite for station data parsers."""
+
+    def test_station_default(self):
+        """Test station parser for default query of station data."""
+        res = download_and_parse("fmi::ef::stations", args=ARGS)
+        _test_verify_station_common(res)
+
+    def test_station_structure(self):
+        """Test the structure of station data."""
+        res = download_and_parse("fmi::ef::stations", args=ARGS)
+        _test_verify_station_common(res)
+
+        # Check the structure of station data for each station
+        for station_id, station_data in res.data.items():
+            # Verify station_id is a string
+            assert isinstance(
+                station_id, str
+            ), f"Station ID should be a string, got {type(station_id)}"
+
+            # Check required fields exist with correct types
+            assert isinstance(station_data, dict), \
+                "Station data should be a dictionary"
+            assert "id" in station_data, \
+                "Station data should have 'id' field"
+            assert "fmisid" in station_data, \
+                "Station data should have 'fmisid' field"
+            assert "name" in station_data, \
+                "Station data should have 'name' field"
+            assert "geoid" in station_data, \
+                "Station data should have 'geoid' field"
+            assert "wmo" in station_data, \
+                "Station data should have 'wmo' field"
+            assert "region" in station_data, \
+                "Station data should have 'region' field"
+            assert "country" in station_data, \
+                "Station data should have 'country' field"
+            assert "station_type" in station_data, \
+                "Station data should have 'station_type' field"
+            assert "latitude" in station_data, \
+                "Station data should have 'latitude' field"
+            assert "longitude" in station_data, \
+                "Station data should have 'longitude' field"
+            assert "start_time" in station_data, \
+                "Station data should have 'start_time' field"
+            assert "end_time" in station_data, \
+                "Station data should have 'end_time' field"
+            assert "inspire_local_id" in station_data, \
+                "Station data should have 'inspire_local_id' field"
+            assert "inspire_namespace" in station_data, \
+                "Station data should have 'inspire_namespace' field"
+            assert "measurement_regime" in station_data, \
+                "Station data should have 'measurement_regime' field"
+            assert "mobile" in station_data, \
+                "Station data should have 'mobile' field"
+
+            # Verify station_type is a list
+            assert isinstance(station_data["station_type"], list), \
+                "station_type should be a list"
+
+    def test_station_position_data(self):
+        """Test position data in station information."""
+        res = download_and_parse("fmi::ef::stations", args=ARGS)
+        _test_verify_station_common(res)
+
+        for _, station_data in res.data.items():
+            # Check position data if latitude and longitude exist
+            if (
+                station_data["latitude"] is not None
+                and station_data["longitude"] is not None
+            ):
+                assert isinstance(
+                    station_data["latitude"], float
+                ), "Latitude should be a float"
+                assert isinstance(
+                    station_data["longitude"], float
+                ), "Longitude should be a float"
+
+    def test_station_time_data(self):
+        """Test time data in station information."""
+        res = download_and_parse("fmi::ef::stations", args=ARGS)
+        _test_verify_station_common(res)
+
+        for _, station_data in res.data.items():
+            # Check start_time if it exists
+            if station_data["start_time"] is not None:
+                assert isinstance(
+                    station_data["start_time"], dt.datetime
+                ), "Start time should be a datetime"
+
+            # Check end_time if it exists
+            if station_data["end_time"] is not None:
+                assert isinstance(
+                    station_data["end_time"], dt.datetime
+                ), "End time should be a datetime"
+
+    def test_get_station_by_id(self):
+        """Test get_station_by_id helper method."""
+        res = download_and_parse("fmi::ef::stations", args=ARGS)
+        _test_verify_station_common(res)
+
+        # Get a sample station ID to test with
+        sample_station_id = next(iter(res.data))
+        sample_station = res.data[sample_station_id]
+
+        # Test get_station_by_id
+        retrieved_station = res.get_station_by_id(sample_station_id)
+        assert (
+            retrieved_station == sample_station
+        ), "get_station_by_id should return the correct station"
+
+    def test_get_station_by_name(self):
+        """Test get_station_by_name helper method."""
+        res = download_and_parse("fmi::ef::stations", args=ARGS)
+        _test_verify_station_common(res)
+
+        # Find a station with a name
+        for _, station_data in res.data.items():
+            if station_data["name"] is not None:
+                name_retrieved_station = res.get_station_by_name(
+                    station_data["name"]
+                )
+                assert (
+                    name_retrieved_station == station_data
+                ), "get_station_by_name should return the correct station"
+                break
+
+    def test_get_stations_by_type(self):
+        """Test get_stations_by_type helper method."""
+        res = download_and_parse("fmi::ef::stations", args=ARGS)
+        _test_verify_station_common(res)
+
+        # Find a station with a type
+        for station_id, station_data in res.data.items():
+            if (
+                station_data.get("station_type") and
+                len(station_data["station_type"]) > 0
+            ):
+                station_type = station_data["station_type"][0]
+
+                type_stations = res.get_stations_by_type(station_type)
+                assert (
+                    station_id in type_stations
+                ), "get_stations_by_type should include the sample station"
+                break
+
+    def test_get_stations_by_country(self):
+        """Test get_stations_by_country helper method."""
+        res = download_and_parse("fmi::ef::stations", args=ARGS)
+        _test_verify_station_common(res)
+
+        # Find a station with a country
+        for station_id, station_data in res.data.items():
+            if station_data.get("country") is not None:
+                country_stations = res.get_stations_by_country(
+                    station_data["country"]
+                )
+                assert (
+                    station_id in country_stations
+                ), "get_stations_by_country should include the sample station"
+                break
+
+    def test_get_stations_by_region(self):
+        """Test get_stations_by_region helper method."""
+        res = download_and_parse("fmi::ef::stations", args=ARGS)
+        _test_verify_station_common(res)
+
+        # Find a station with a region
+        for station_id, station_data in res.data.items():
+            if station_data.get("region") is not None:
+                region_stations = res.get_stations_by_region(
+                    station_data["region"]
+                )
+                assert (
+                    station_id in region_stations
+                ), "get_stations_by_region should include the sample station"
+                break
+
+    def test_station_inspire_id_structure(self):
+        """Test INSPIRE ID fields when present."""
+        res = download_and_parse("fmi::ef::stations", args=ARGS)
+        _test_verify_station_common(res)
+
+        # Find a station with INSPIRE ID
+        for _, station_data in res.data.items():
+            if station_data["inspire_local_id"] is not None:
+                assert isinstance(
+                    station_data["inspire_local_id"], str
+                ), "INSPIRE local ID should be a string"
+                assert (
+                    station_data["inspire_local_id"] == station_data["fmisid"]
+                ), "INSPIRE local ID should match FMISID"
+                break
+
+    def test_station_inspire_namespace(self):
+        """Test INSPIRE namespace field when present."""
+        res = download_and_parse("fmi::ef::stations", args=ARGS)
+        _test_verify_station_common(res)
+
+        # Find a station with INSPIRE namespace
+        for _, station_data in res.data.items():
+            if station_data["inspire_namespace"] is not None:
+                assert isinstance(
+                    station_data["inspire_namespace"], str
+                ), "INSPIRE namespace should be a string"
+                assert "http" in station_data["inspire_namespace"], \
+                    "INSPIRE namespace should be a URL"
+                break
+
+    def test_station_measurement_regime(self):
+        """Test measurement regime field when present."""
+        res = download_and_parse("fmi::ef::stations", args=ARGS)
+        _test_verify_station_common(res)
+
+        # Find a station with measurement regime
+        for _, station_data in res.data.items():
+            if station_data["measurement_regime"] is not None:
+                assert isinstance(
+                    station_data["measurement_regime"], str
+                ), "Measurement regime should be a string"
+                # Common values include continuousDataCollection
+                assert len(station_data["measurement_regime"]) > 0, \
+                    "Measurement regime should not be empty"
+                break
+
+    def test_station_mobile_field(self):
+        """Test mobile field is boolean when present."""
+        res = download_and_parse("fmi::ef::stations", args=ARGS)
+        _test_verify_station_common(res)
+
+        # Find a station with mobile field set
+        for _, station_data in res.data.items():
+            if station_data["mobile"] is not None:
+                assert isinstance(
+                    station_data["mobile"], bool
+                ), "Mobile field should be a boolean"
+                # Most FMI stations are stationary
+                break
+
+
+class TestStationValues:
+    """Test types and values in station data parser's output."""
+
+    def test_station_type_is_list(self):
+        """Test that station_type field is always a list."""
+        res = download_and_parse("fmi::ef::stations", args=ARGS)
+        _test_verify_station_common(res)
+
+        for _, station_data in res.data.items():
+            assert isinstance(
+                station_data["station_type"], list
+            ), "station_type should be a list"
+
+    def test_station_with_multiple_station_types(self):
+        """Test handling of stations with multiple station types."""
+        res = download_and_parse("fmi::ef::stations", args=ARGS)
+        _test_verify_station_common(res)
+
+        # Find a station with multiple network types
+        found_multiple_types = False
+        for _, station_data in res.data.items():
+            if len(station_data["station_type"]) > 1:
+                found_multiple_types = True
+
+                # Verify all entries are strings
+                for network_type in station_data["station_type"]:
+                    assert isinstance(
+                        network_type, str
+                    ), "Each network type should be a string"
+
+                break
+
+        # Note: This test may not always find a multi-network station
+        # depending on the data range queried
+        if found_multiple_types:
+            assert True, "Found station with multiple network types"
+
+    def test_station_coordinates_validity(self):
+        """Test that coordinates are within valid ranges."""
+        res = download_and_parse("fmi::ef::stations", args=ARGS)
+        _test_verify_station_common(res)
+
+        for _, station_data in res.data.items():
+            if (
+                station_data["latitude"] is not None
+                and station_data["longitude"] is not None
+            ):
+                # Valid latitude range
+                assert -90 <= station_data["latitude"] <= 90, \
+                    f"Invalid latitude: {station_data['latitude']}"
+                # Valid longitude range
+                assert -180 <= station_data["longitude"] <= 180, \
+                    f"Invalid longitude: {station_data['longitude']}"
+
+                # For Finnish stations, rough bounds
+                if station_data["country"] == "Finland":
+                    assert 59 <= station_data["latitude"] <= 71, \
+                        "Finnish station latitude should be between 59-71"
+                    assert 19 <= station_data["longitude"] <= 33, \
+                        "Finnish station longitude should be between 19-33"
+
+    def test_station_time_order(self):
+        """Test that start_time is before end_time."""
+        res = download_and_parse("fmi::ef::stations", args=ARGS)
+        _test_verify_station_common(res)
+
+        for _, station_data in res.data.items():
+            if (
+                station_data["start_time"] is not None
+                and station_data["end_time"] is not None
+            ):
+                assert (
+                    station_data["start_time"] <= station_data["end_time"]
+                ), "start_time should be before or equal to end_time"
+
+    def test_station_geoid_format(self):
+        """Test geoid field format when present."""
+        res = download_and_parse("fmi::ef::stations", args=ARGS)
+        _test_verify_station_common(res)
+
+        # Find a station with geoid
+        for _, station_data in res.data.items():
+            if station_data["geoid"] is not None:
+                assert isinstance(
+                    station_data["geoid"], str
+                ), "Geoid should be a string"
+                # Geoids in the sample are negative integers as strings
+                assert station_data["geoid"].startswith("-") or \
+                    station_data["geoid"].isdigit(), \
+                    "Geoid should be a negative numeric string"
+                break
+
+    def test_station_wmo_format(self):
+        """Test WMO ID field format when present."""
+        res = download_and_parse("fmi::ef::stations", args=ARGS)
+        _test_verify_station_common(res)
+
+        # Find a station with WMO ID
+        for _, station_data in res.data.items():
+            if station_data["wmo"] is not None:
+                assert isinstance(
+                    station_data["wmo"], str
+                ), "WMO ID should be a string"
+                assert len(station_data["wmo"]) == 5, \
+                    "WMO ID should be 5 digits"
+                assert station_data["wmo"].isdigit(), \
+                    "WMO ID should be numeric"
+                break
+
+    def test_station_fmisid_matches_station_id(self):
+        """Test that fmisid field matches the dictionary key."""
+        res = download_and_parse("fmi::ef::stations", args=ARGS)
+        _test_verify_station_common(res)
+
+        for station_id, station_data in res.data.items():
+            assert station_id == station_data["fmisid"], \
+                "Station ID key should match fmisid field"
+
+    def test_station_data_consistency(self):
+        """Test that all stations have consistent structure."""
+        res = download_and_parse("fmi::ef::stations", args=ARGS)
+        _test_verify_station_common(res)
+
+        # Get the keys from the first station
+        first_station = next(iter(res.data.values()))
+        expected_keys = set(first_station.keys())
+
+        # Verify all stations have the same keys
+        for station_id, station_data in res.data.items():
+            actual_keys = set(station_data.keys())
+            assert actual_keys == expected_keys, \
+                f"Station {station_id} has inconsistent keys"
+
+    def test_station_at_least_one_field_populated(self):
+        """Test that each station has at least some data populated."""
+        res = download_and_parse("fmi::ef::stations", args=ARGS)
+        _test_verify_station_common(res)
+
+        for station_id, station_data in res.data.items():
+            # Count non-None values
+            #  (excluding the list which is always present)
+            populated_fields = sum(
+                1 for k, v in station_data.items()
+                if v is not None and k != "station_type"
+            )
+            assert populated_fields > 0, \
+                f"Station {station_id} has no populated fields"
+
+    def test_get_stations_by_type_returns_correct_stations(self):
+        """Test that get_stations_by_type returns only matching stations."""
+        res = download_and_parse("fmi::ef::stations", args=ARGS)
+        _test_verify_station_common(res)
+
+        # Find a station with a network type
+        for _, station_data in res.data.items():
+            if station_data["station_type"]:
+                network_type = station_data["station_type"][0]
+                matching_stations = res.get_stations_by_type(network_type)
+
+                # Verify all returned stations have the network type
+                for _, matched_station in matching_stations.items():
+                    assert network_type in matched_station["station_type"], \
+                        "Returned station should have the queried network type"
+                break
+
+    def test_station_country_values(self):
+        """Test that country field has expected values."""
+        res = download_and_parse("fmi::ef::stations", args=ARGS)
+        _test_verify_station_common(res)
+
+        countries_found = set()
+        for _, station_data in res.data.items():
+            if station_data["country"] is not None:
+                countries_found.add(station_data["country"])
+
+        # FMI primarily has Finnish stations
+        assert "Finland" in countries_found, \
+            "Should have at least some Finnish stations"
+
+    def test_station_name_not_empty(self):
+        """Test that station names are not empty strings when present."""
+        res = download_and_parse("fmi::ef::stations", args=ARGS)
+        _test_verify_station_common(res)
+
+        for station_id, station_data in res.data.items():
+            if station_data["name"] is not None:
+                assert len(station_data["name"]) > 0, \
+                    f"Station {station_id} name should not be empty"
+
+
+class TestStationErrorCases:
+    """Test error handling in station data parsers."""
+
+    def test_invalid_query(self):
+        """Test handling of invalid stored query ID."""
+        query_id = "invalid::stored::query"
+        try:
+            # Ignore warnings about not having a handler for this query ID
+            # as we are testing error handling here for a case
+            # that does not have a handler.
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                download_and_parse(query_id, args=ARGS)
+        except NotImplementedError as e:
+            expected_msg = (
+                f"Custom parsing for query ID '{query_id}' not implemented!"
+            )
+            assert str(e) == expected_msg, \
+                "Error message does not match expected handler error message!"
+        else:
+            raise AssertionError(
+                "Expected NotImplementedError for invalid query ID"
+            )
+
+    def test_get_station_by_id_nonexistent(self):
+        """Test get_station_by_id with non-existent ID returns None."""
+        res = download_and_parse("fmi::ef::stations", args=ARGS)
+        _test_verify_station_common(res)
+
+        # Use an ID that shouldn't exist
+        nonexistent_station = res.get_station_by_id("999999999")
+        assert nonexistent_station is None, \
+            "Should return None for non-existent station ID"
+
+    def test_get_station_by_name_nonexistent(self):
+        """Test get_station_by_name with non-existent name returns None."""
+        res = download_and_parse("fmi::ef::stations", args=ARGS)
+        _test_verify_station_common(res)
+
+        # Use a name that shouldn't exist
+        nonexistent_station = res.get_station_by_name(
+            "NonExistent Station 12345"
+        )
+        assert nonexistent_station is None, \
+            "Should return None for non-existent station name"
+
+    def test_get_stations_by_type_nonexistent(self):
+        """Test get_stations_by_type with non-existent type returns empty."""
+        res = download_and_parse("fmi::ef::stations", args=ARGS)
+        _test_verify_station_common(res)
+
+        # Use a type that shouldn't exist
+        nonexistent_stations = res.get_stations_by_type(
+            "NonExistent Type 12345"
+        )
+        assert len(nonexistent_stations) == 0, \
+            "Should return empty dict for non-existent station type"
+
+    def test_get_stations_by_country_nonexistent(self):
+        """Test get_stations_by_country with non-existent country."""
+        res = download_and_parse("fmi::ef::stations", args=ARGS)
+        _test_verify_station_common(res)
+
+        # Use a country that shouldn't exist
+        nonexistent_stations = res.get_stations_by_country("Antarctica")
+        assert len(nonexistent_stations) == 0, \
+            "Should return empty dict for non-existent country"
+
+    def test_get_stations_by_region_nonexistent(self):
+        """Test get_stations_by_region with non-existent region."""
+        res = download_and_parse("fmi::ef::stations", args=ARGS)
+        _test_verify_station_common(res)
+
+        # Use a region that shouldn't exist
+        nonexistent_stations = res.get_stations_by_region(
+            "NonExistent Region 12345"
+        )
+        assert len(nonexistent_stations) == 0, \
+            "Should return empty dict for non-existent region"

--- a/fmiopendata/wfs.py
+++ b/fmiopendata/wfs.py
@@ -27,6 +27,14 @@ from fmiopendata.utils import read_url
 BASE_URL = "https://opendata.fmi.fi/wfs?service=WFS&request="
 STORED_QUERY_URL = "https://opendata.fmi.fi/wfs?service=WFS&version=2.0.0&request=getFeature&storedquery_id="
 
+EF_BELONGS_TO = ".//{http://inspire.ec.europa.eu/schemas/ef/4.0}belongsTo"
+EF_ENVIRONMENTAL_MONITORING_FACILITY = (
+    ".//{http://inspire.ec.europa.eu/schemas/ef/4.0}EnvironmentalMonitoringFacility"
+)
+EF_NAME = ".//{http://inspire.ec.europa.eu/schemas/ef/4.0}name"
+EF_INSPIRE_ID = ".//{http://inspire.ec.europa.eu/schemas/ef/4.0}inspireId"
+EF_MOBILE = ".//{http://inspire.ec.europa.eu/schemas/ef/4.0}mobile"
+EF_MEASUREMENT_REGIME = ".//{http://inspire.ec.europa.eu/schemas/ef/4.0}measurementRegime"
 GML_BEGIN_POSITION = ".//{http://www.opengis.net/gml/3.2}beginPosition"
 GML_DOUBLE_OR_NIL_REASON_TUPLE_LIST = ".//{http://www.opengis.net/gml/3.2}doubleOrNilReasonTupleList"
 GML_END_POSITION = ".//{http://www.opengis.net/gml/3.2}endPosition"
@@ -38,8 +46,11 @@ GML_NAME = ".//{http://www.opengis.net/gml/3.2}name"
 GML_POINT = ".//{http://www.opengis.net/gml/3.2}Point"
 GML_POS = ".//{http://www.opengis.net/gml/3.2}pos"
 GML_TIME_INSTANT = ".//{http://www.opengis.net/gml/3.2}TimeInstant"
+GML_TIME_PERIOD = ".//{http://www.opengis.net/gml/3.2}TimePeriod"
 GML_TIME_POSITION = ".//{http://www.opengis.net/gml/3.2}timePosition"
 GMLCOV_POSITIONS = ".//{http://www.opengis.net/gmlcov/1.0}positions"
+INS_BASE_LOCAL_ID = ".//{http://inspire.ec.europa.eu/schemas/base/3.3}localId"
+INS_BASE_NAMESPACE = ".//{http://inspire.ec.europa.eu/schemas/base/3.3}namespace"
 LINK = "{http://www.w3.org/1999/xlink}href"
 OM_NAME = ".//{http://www.opengis.net/om/2.0}name"
 OM_PARAMETER = ".//{http://www.opengis.net/om/2.0}parameter"
@@ -59,6 +70,7 @@ WFS_RETURN_FEATURE_TYPE = ".//{http://www.opengis.net/wfs/2.0}ReturnFeatureType"
 WFS_STORED_QUERY = ".//{http://www.opengis.net/wfs/2.0}StoredQuery"
 WFS_TIME = ".//{http://xml.fmi.fi/schema/wfs/2.0}Time"
 WFS_TITLE = ".//{http://www.opengis.net/wfs/2.0}Title"
+XLINK_TITLE = "{http://www.w3.org/1999/xlink}title"
 
 
 def get_req_xml(req):
@@ -118,6 +130,8 @@ def download_stored_query(query_id, args=None):
         from fmiopendata.grid import download_and_parse
     elif "multipointcoverage" in query_id.lower():
         from fmiopendata.multipoint import download_and_parse
+    elif "station" in query_id.lower():
+        from fmiopendata.station import download_and_parse
     else:
         raise NotImplementedError("No parser available for %s" % query_id)
 


### PR DESCRIPTION
I have added the support for station metadata API endpoint (`fmi::ef::stations`) and functionality to `download_and_parse` that data.

Changes:
- `station.py` file added. Implements `download_and_parse` for the stations.
- `test_station.py `file added. Test the `station.py` implementation.
- `wfs.py` updated to included necessary XML Elements used by `station.py`.
- `README.MD` section added for stations. Examples included there.